### PR TITLE
build-disk-impl: update to use `bootc install to-disk`

### DIFF
--- a/cmd/builddiskimpl/builddiskimpl.go
+++ b/cmd/builddiskimpl/builddiskimpl.go
@@ -58,7 +58,7 @@ func run(cmd *cobra.Command, args []string) error {
 		podmanArgs = append(podmanArgs, "--env", "RUST_LOG="+config.BootcLogLevel)
 	}
 	podmanArgs = append(podmanArgs, tmp)
-	podmanArgs = append(podmanArgs, "bootc", "install")
+	podmanArgs = append(podmanArgs, "bootc", "install", "to-disk")
 	podmanArgs = append(podmanArgs, config.InstallArgs...)
 	podmanArgs = append(podmanArgs, "--generic-image")
 	disk, err := filepath.EvalSymlinks(config.Disk)


### PR DESCRIPTION
Required since https://github.com/containers/bootc/pull/226